### PR TITLE
feat!: replace global terminal mutex with per-process ResourceArc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: Terminal state is now per-process via Rust ResourceArc instead of a global mutex
+  - `ExRatatui.run/1` closure now receives the terminal reference (1-arity)
+  - `ExRatatui.draw/1` is now `ExRatatui.draw/2` (terminal reference as first argument)
+  - `ExRatatui.init_test_terminal/2` returns a terminal reference instead of `:ok`
+  - `ExRatatui.get_buffer_content/0` is now `ExRatatui.get_buffer_content/1`
+  - `ExRatatui.App` behaviour users: **no API changes**
+- Terminal is automatically restored when the terminal reference is garbage collected (crash safety)
+- Test terminal instances are now independent, enabling `async: true` for rendering tests
+
 ## [0.3.0] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ alias ExRatatui.Layout.Rect
 alias ExRatatui.Style
 alias ExRatatui.Widgets.{Block, Paragraph}
 
-ExRatatui.run(fn ->
+ExRatatui.run(fn terminal ->
   {w, h} = ExRatatui.terminal_size()
 
   paragraph = %Paragraph{
@@ -88,7 +88,7 @@ ExRatatui.run(fn ->
     }
   }
 
-  ExRatatui.draw([{paragraph, %Rect{x: 0, y: 0, width: w, height: h}}])
+  ExRatatui.draw(terminal, [{paragraph, %Rect{x: 0, y: 0, width: w, height: h}}])
 
   # Wait for a keypress, then exit
   ExRatatui.poll_event(60_000)
@@ -165,7 +165,7 @@ Terminal events -> Rust NIF (DirtyIo) -> encode to tuples -> Elixir Event struct
 
 - **Rendering:** Elixir widget structs are encoded as string-keyed maps, passed across the NIF boundary, and decoded into ratatui widget types for rendering.
 - **Events:** The `poll_event` NIF runs on BEAM's DirtyIo scheduler, so event polling never blocks normal Elixir processes.
-- **Terminal state:** Managed in Rust via a global mutex supporting two backends — a real crossterm terminal and a headless test backend for CI.
+- **Terminal state:** Each process holds its own terminal reference via Rust ResourceArc, supporting two backends — a real crossterm terminal and a headless test backend for CI. The terminal is automatically restored when the reference is garbage collected.
 - **Layout:** Ratatui's constraint-based layout engine is exposed directly, computing split rectangles on the Rust side and returning them as Elixir tuples.
 
 Precompiled binaries are provided via [rustler_precompiled](https://github.com/philss/rustler_precompiled) so users don't need the Rust toolchain.
@@ -311,16 +311,16 @@ end
 
 ## Testing
 
-ExRatatui includes a headless test backend for CI-friendly rendering verification:
+ExRatatui includes a headless test backend for CI-friendly rendering verification. Each test terminal is independent, enabling `async: true` tests:
 
 ```elixir
 test "renders a paragraph" do
-  :ok = ExRatatui.init_test_terminal(40, 10)
+  terminal = ExRatatui.init_test_terminal(40, 10)
 
   paragraph = %Paragraph{text: "Hello!"}
-  :ok = ExRatatui.draw([{paragraph, %Rect{x: 0, y: 0, width: 40, height: 10}}])
+  :ok = ExRatatui.draw(terminal, [{paragraph, %Rect{x: 0, y: 0, width: 40, height: 10}}])
 
-  content = ExRatatui.get_buffer_content()
+  content = ExRatatui.get_buffer_content(terminal)
   assert content =~ "Hello!"
 end
 ```

--- a/examples/counter.exs
+++ b/examples/counter.exs
@@ -10,12 +10,12 @@ alias ExRatatui.Event
 
 defmodule Counter do
   def run do
-    ExRatatui.run(fn ->
-      loop(0)
+    ExRatatui.run(fn terminal ->
+      loop(terminal, 0)
     end)
   end
 
-  defp loop(count) do
+  defp loop(terminal, count) do
     {w, h} = ExRatatui.terminal_size()
 
     paragraph = %Paragraph{
@@ -24,20 +24,20 @@ defmodule Counter do
       alignment: :center
     }
 
-    ExRatatui.draw([{paragraph, %Rect{x: 0, y: 0, width: w, height: h}}])
+    ExRatatui.draw(terminal, [{paragraph, %Rect{x: 0, y: 0, width: w, height: h}}])
 
     case ExRatatui.poll_event(100) do
       %Event.Key{code: "q", kind: "press"} ->
         :ok
 
       %Event.Key{code: code, kind: "press"} when code in ["up", "k"] ->
-        loop(count + 1)
+        loop(terminal, count + 1)
 
       %Event.Key{code: code, kind: "press"} when code in ["down", "j"] ->
-        loop(count - 1)
+        loop(terminal, count - 1)
 
       _ ->
-        loop(count)
+        loop(terminal, count)
     end
   end
 end

--- a/examples/hello_world.exs
+++ b/examples/hello_world.exs
@@ -7,7 +7,7 @@ alias ExRatatui.Widgets.{Block, Paragraph}
 
 defmodule HelloWorld do
   def run do
-    ExRatatui.run(fn ->
+    ExRatatui.run(fn terminal ->
       {w, h} = ExRatatui.terminal_size()
 
       paragraph = %Paragraph{
@@ -22,7 +22,7 @@ defmodule HelloWorld do
         }
       }
 
-      ExRatatui.draw([{paragraph, %Rect{x: 0, y: 0, width: w, height: h}}])
+      ExRatatui.draw(terminal, [{paragraph, %Rect{x: 0, y: 0, width: w, height: h}}])
       wait_for_key()
     end)
   end

--- a/examples/task_manager.exs
+++ b/examples/task_manager.exs
@@ -52,8 +52,8 @@ defmodule TaskTracker do
   }
 
   def run do
-    ExRatatui.run(fn ->
-      loop(%{
+    ExRatatui.run(fn terminal ->
+      loop(terminal, %{
         focus: :team,
         team_selected: 0,
         task_selected: 0,
@@ -73,7 +73,7 @@ defmodule TaskTracker do
     %{state | boards: Map.put(state.boards, current_member(state), tasks)}
   end
 
-  defp loop(state) do
+  defp loop(terminal, state) do
     {w, h} = ExRatatui.terminal_size()
     area = %Rect{x: 0, y: 0, width: w, height: h}
 
@@ -97,7 +97,7 @@ defmodule TaskTracker do
       {status_widget(state), status_area}
     ]
 
-    ExRatatui.draw(widgets)
+    ExRatatui.draw(terminal, widgets)
 
     case ExRatatui.poll_event(100) do
       %Event.Key{code: "q", kind: "press"} when state.input_mode == nil ->
@@ -106,41 +106,41 @@ defmodule TaskTracker do
       # --- Input mode: typing a new task name ---
       %Event.Key{code: "enter", kind: "press"} when state.input_mode == :new_task ->
         state = create_task(state)
-        loop(%{state | input_mode: nil, input_buffer: "", tick: state.tick + 1})
+        loop(terminal, %{state | input_mode: nil, input_buffer: "", tick: state.tick + 1})
 
       %Event.Key{code: "esc", kind: "press"} when state.input_mode != nil ->
-        loop(%{state | input_mode: nil, input_buffer: "", tick: state.tick + 1})
+        loop(terminal, %{state | input_mode: nil, input_buffer: "", tick: state.tick + 1})
 
       %Event.Key{code: "backspace", kind: "press"} when state.input_mode != nil ->
         buf = String.slice(state.input_buffer, 0..-2//1)
-        loop(%{state | input_buffer: buf, tick: state.tick + 1})
+        loop(terminal, %{state | input_buffer: buf, tick: state.tick + 1})
 
       %Event.Key{code: char, kind: "press"}
       when state.input_mode != nil and byte_size(char) == 1 ->
-        loop(%{state | input_buffer: state.input_buffer <> char, tick: state.tick + 1})
+        loop(terminal, %{state | input_buffer: state.input_buffer <> char, tick: state.tick + 1})
 
       # --- Normal mode ---
       %Event.Key{code: "tab", kind: "press"} ->
-        loop(%{state | focus: next_panel(state.focus), tick: state.tick + 1})
+        loop(terminal, %{state | focus: next_panel(state.focus), tick: state.tick + 1})
 
       %Event.Key{code: code, kind: "press"} when code in ["up", "k"] ->
-        loop(move_selection(state, -1))
+        loop(terminal, move_selection(state, -1))
 
       %Event.Key{code: code, kind: "press"} when code in ["down", "j"] ->
-        loop(move_selection(state, 1))
+        loop(terminal, move_selection(state, 1))
 
       %Event.Key{code: code, kind: "press"}
       when code in ["enter", " "] and state.focus == :tasks ->
-        loop(toggle_task_status(state))
+        loop(terminal, toggle_task_status(state))
 
       %Event.Key{code: "n", kind: "press"} when state.focus == :tasks ->
-        loop(%{state | input_mode: :new_task, input_buffer: "", tick: state.tick + 1})
+        loop(terminal, %{state | input_mode: :new_task, input_buffer: "", tick: state.tick + 1})
 
       %Event.Key{code: "d", kind: "press"} when state.focus == :tasks ->
-        loop(delete_task(state))
+        loop(terminal, delete_task(state))
 
       _ ->
-        loop(%{state | tick: state.tick + 1})
+        loop(terminal, %{state | tick: state.tick + 1})
     end
   end
 

--- a/lib/ex_ratatui.ex
+++ b/lib/ex_ratatui.ex
@@ -10,6 +10,8 @@ defmodule ExRatatui do
   alias ExRatatui.Style
   alias ExRatatui.Widgets.{Block, Gauge, List, Paragraph, Table}
 
+  @type terminal_ref :: reference()
+
   @type widget ::
           Paragraph.t()
           | Block.t()
@@ -20,24 +22,25 @@ defmodule ExRatatui do
   @doc """
   Runs a TUI application.
 
-  Initializes the terminal, calls `fun`, and ensures terminal cleanup on exit.
+  Initializes the terminal, calls `fun` with the terminal reference,
+  and ensures terminal cleanup on exit.
 
-      ExRatatui.run(fn ->
+      ExRatatui.run(fn terminal ->
         # your TUI loop here
       end)
   """
-  @spec run((-> term())) :: term() | {:error, term()}
-  def run(fun) when is_function(fun, 0) do
+  @spec run((terminal_ref() -> term())) :: term() | {:error, term()}
+  def run(fun) when is_function(fun, 1) do
     case Native.init_terminal() do
-      :ok ->
-        try do
-          fun.()
-        after
-          Native.restore_terminal()
-        end
-
       {:error, reason} ->
         {:error, reason}
+
+      terminal_ref ->
+        try do
+          fun.(terminal_ref)
+        after
+          Native.restore_terminal(terminal_ref)
+        end
     end
   end
 
@@ -46,14 +49,14 @@ defmodule ExRatatui do
 
   Returns `:ok` on success or `{:error, reason}` on failure.
 
-      ExRatatui.draw([
+      ExRatatui.draw(terminal, [
         {%ExRatatui.Widgets.Paragraph{text: "Hello!"}, rect}
       ])
   """
-  @spec draw([{widget(), Rect.t()}]) :: :ok | {:error, term()}
-  def draw(widgets) when is_list(widgets) do
+  @spec draw(terminal_ref(), [{widget(), Rect.t()}]) :: :ok | {:error, term()}
+  def draw(terminal_ref, widgets) when is_list(widgets) do
     commands = Enum.map(widgets, &encode_command/1)
-    Native.draw_frame(commands)
+    Native.draw_frame(terminal_ref, commands)
   end
 
   @doc """
@@ -102,13 +105,14 @@ defmodule ExRatatui do
   Initializes a headless test terminal with the given dimensions.
 
   Uses ratatui's TestBackend — no real terminal needed. Useful for testing
-  rendering output without a TTY.
+  rendering output without a TTY. Returns a terminal reference.
 
-      :ok = ExRatatui.init_test_terminal(80, 24)
-      ExRatatui.draw([{widget, rect}])
-      content = ExRatatui.get_buffer_content()
+      terminal = ExRatatui.init_test_terminal(80, 24)
+      ExRatatui.draw(terminal, [{widget, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
   """
-  @spec init_test_terminal(non_neg_integer(), non_neg_integer()) :: :ok | {:error, term()}
+  @spec init_test_terminal(non_neg_integer(), non_neg_integer()) ::
+          terminal_ref() | {:error, term()}
   def init_test_terminal(width, height) do
     Native.init_test_terminal(width, height)
   end
@@ -117,14 +121,14 @@ defmodule ExRatatui do
   Returns the test terminal's buffer contents as a string.
 
   Each line is trimmed of trailing whitespace and joined with newlines.
-  Only works after `init_test_terminal/2`.
+  Only works with a test terminal reference from `init_test_terminal/2`.
   """
-  @spec get_buffer_content() :: String.t() | {:error, term()}
-  def get_buffer_content do
-    Native.get_buffer_content()
+  @spec get_buffer_content(terminal_ref()) :: String.t() | {:error, term()}
+  def get_buffer_content(terminal_ref) do
+    Native.get_buffer_content(terminal_ref)
   end
 
-  # -- Encoding: Elixir structs → string-keyed maps for NIF --
+  # -- Encoding: Elixir structs -> string-keyed maps for NIF --
 
   defp encode_command({widget, %Rect{} = rect}) do
     {encode_widget(widget), encode_rect(rect)}

--- a/lib/ex_ratatui/native.ex
+++ b/lib/ex_ratatui/native.ex
@@ -27,11 +27,12 @@ defmodule ExRatatui.Native do
 
   @doc false
   # Enters raw mode, alternate screen, and creates a crossterm-backed terminal.
+  # Returns a terminal reference (ResourceArc).
   def init_terminal, do: :erlang.nif_error(:not_loaded)
 
   @doc false
   # Leaves alternate screen and disables raw mode. Safe to call multiple times.
-  def restore_terminal, do: :erlang.nif_error(:not_loaded)
+  def restore_terminal(_terminal_ref), do: :erlang.nif_error(:not_loaded)
 
   @doc false
   # Returns `{width, height}` of the current terminal.
@@ -41,7 +42,7 @@ defmodule ExRatatui.Native do
 
   @doc false
   # Draws a list of `{widget_map, rect_map}` tuples in a single frame.
-  def draw_frame(_commands), do: :erlang.nif_error(:not_loaded)
+  def draw_frame(_terminal_ref, _commands), do: :erlang.nif_error(:not_loaded)
 
   # Events
 
@@ -59,9 +60,10 @@ defmodule ExRatatui.Native do
 
   @doc false
   # Creates a headless test terminal with given dimensions.
+  # Returns a terminal reference (ResourceArc).
   def init_test_terminal(_width, _height), do: :erlang.nif_error(:not_loaded)
 
   @doc false
   # Returns the test terminal's buffer contents as a string.
-  def get_buffer_content, do: :erlang.nif_error(:not_loaded)
+  def get_buffer_content(_terminal_ref), do: :erlang.nif_error(:not_loaded)
 end

--- a/lib/ex_ratatui/server.ex
+++ b/lib/ex_ratatui/server.ex
@@ -8,7 +8,14 @@ defmodule ExRatatui.Server do
   alias ExRatatui.Frame
   alias ExRatatui.Native
 
-  defstruct [:mod, :user_state, :test_mode, poll_interval: 16, terminal_initialized: false]
+  defstruct [
+    :mod,
+    :user_state,
+    :test_mode,
+    :terminal_ref,
+    poll_interval: 16,
+    terminal_initialized: false
+  ]
 
   @doc false
   def start_link(opts) do
@@ -32,7 +39,10 @@ defmodule ExRatatui.Server do
     Process.flag(:trap_exit, true)
 
     case init_terminal(test_mode) do
-      :ok ->
+      {:error, reason} ->
+        {:stop, {:terminal_init_failed, reason}}
+
+      terminal_ref ->
         case mod.mount(opts) do
           {:ok, user_state} ->
             state = %__MODULE__{
@@ -40,6 +50,7 @@ defmodule ExRatatui.Server do
               user_state: user_state,
               poll_interval: poll_interval,
               test_mode: test_mode,
+              terminal_ref: terminal_ref,
               terminal_initialized: true
             }
 
@@ -49,12 +60,9 @@ defmodule ExRatatui.Server do
             {:ok, state}
 
           {:error, reason} ->
-            restore_terminal()
+            restore_terminal(terminal_ref)
             {:stop, reason}
         end
-
-      {:error, reason} ->
-        {:stop, {:terminal_init_failed, reason}}
     end
   end
 
@@ -98,7 +106,7 @@ defmodule ExRatatui.Server do
 
   @impl true
   def terminate(reason, %__MODULE__{terminal_initialized: true} = state) do
-    restore_terminal()
+    restore_terminal(state.terminal_ref)
     state.mod.terminate(reason, state.user_state)
     :ok
   end
@@ -110,8 +118,8 @@ defmodule ExRatatui.Server do
   defp init_terminal(nil), do: Native.init_terminal()
   defp init_terminal({width, height}), do: ExRatatui.init_test_terminal(width, height)
 
-  defp restore_terminal do
-    Native.restore_terminal()
+  defp restore_terminal(terminal_ref) do
+    Native.restore_terminal(terminal_ref)
   rescue
     e ->
       Logger.warning("Failed to restore terminal: #{Exception.message(e)}")
@@ -144,7 +152,7 @@ defmodule ExRatatui.Server do
     frame = %Frame{width: w, height: h}
 
     widgets = state.mod.render(state.user_state, frame)
-    draw_widgets(widgets)
+    draw_widgets(state.terminal_ref, widgets)
     state
   rescue
     e ->
@@ -152,10 +160,10 @@ defmodule ExRatatui.Server do
       state
   end
 
-  defp draw_widgets([]), do: :ok
+  defp draw_widgets(_terminal_ref, []), do: :ok
 
-  defp draw_widgets(widgets) do
-    case ExRatatui.draw(widgets) do
+  defp draw_widgets(terminal_ref, widgets) do
+    case ExRatatui.draw(terminal_ref, widgets) do
       :ok -> :ok
       {:error, reason} -> Logger.error("ExRatatui draw error: #{inspect(reason)}")
     end

--- a/native/ex_ratatui/src/rendering.rs
+++ b/native/ex_ratatui/src/rendering.rs
@@ -1,10 +1,10 @@
 use ratatui::layout::{Alignment, Rect};
-use rustler::{Atom, Error, Term};
+use rustler::{Atom, Error, ResourceArc, Term};
 use std::collections::HashMap;
 
 use crate::layout::decode_constraint;
 use crate::style::decode_style;
-use crate::terminal::with_terminal_draw;
+use crate::terminal::{with_terminal_draw, TerminalResource};
 use crate::widgets::block::{self, BlockData};
 use crate::widgets::gauge::{self, GaugeData};
 use crate::widgets::list::{self, ListData};
@@ -25,11 +25,11 @@ struct RenderCommand {
 }
 
 #[rustler::nif]
-fn draw_frame(commands: Term) -> Result<Atom, Error> {
+fn draw_frame(resource: ResourceArc<TerminalResource>, commands: Term) -> Result<Atom, Error> {
     let command_list: Vec<(Term, Term)> = commands.decode()?;
     let render_commands = decode_commands(&command_list)?;
 
-    with_terminal_draw(|frame| {
+    with_terminal_draw(&resource, |frame| {
         for cmd in &render_commands {
             render_widget(frame, cmd);
         }

--- a/native/ex_ratatui/src/terminal.rs
+++ b/native/ex_ratatui/src/terminal.rs
@@ -6,7 +6,7 @@ use crossterm::ExecutableCommand;
 use ratatui::backend::{CrosstermBackend, TestBackend};
 use ratatui::Terminal;
 
-use rustler::{Atom, Error};
+use rustler::{Atom, Error, Resource, ResourceArc};
 
 mod atoms {
     rustler::atoms! {
@@ -15,20 +15,43 @@ mod atoms {
 }
 
 /// Supports both real (crossterm) and test (headless) terminals.
-enum AnyTerminal {
+pub(crate) enum AnyTerminal {
     Crossterm(Terminal<CrosstermBackend<Stdout>>),
     Test(Terminal<TestBackend>),
 }
 
-/// Global terminal state — one terminal per BEAM node.
-static TERMINAL: Mutex<Option<AnyTerminal>> = Mutex::new(None);
+/// Per-process terminal resource, wrapped in a ResourceArc for BEAM GC integration.
+pub struct TerminalResource {
+    pub terminal: Mutex<Option<AnyTerminal>>,
+    is_crossterm: bool,
+}
 
-/// Draw a frame using whichever terminal is currently initialized.
-pub fn with_terminal_draw<F>(f: F) -> Result<Atom, Error>
+#[rustler::resource_impl]
+impl Resource for TerminalResource {}
+
+impl Drop for TerminalResource {
+    fn drop(&mut self) {
+        let mut guard = match self.terminal.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+
+        if self.is_crossterm {
+            if let Some(AnyTerminal::Crossterm(_)) = guard.take() {
+                let _ = terminal::disable_raw_mode();
+                let _ = std::io::stdout().execute(LeaveAlternateScreen);
+            }
+        }
+    }
+}
+
+/// Draw a frame using the given terminal resource.
+pub fn with_terminal_draw<F>(resource: &TerminalResource, f: F) -> Result<Atom, Error>
 where
     F: FnOnce(&mut ratatui::Frame),
 {
-    let mut guard = TERMINAL
+    let mut guard = resource
+        .terminal
         .lock()
         .map_err(|_| Error::Term(Box::new("terminal lock poisoned")))?;
     let terminal = guard
@@ -45,7 +68,7 @@ where
 }
 
 #[rustler::nif]
-fn init_terminal() -> Result<Atom, Error> {
+fn init_terminal() -> Result<ResourceArc<TerminalResource>, Error> {
     terminal::enable_raw_mode().map_err(|e| Error::Term(Box::new(format!("{e}"))))?;
     std::io::stdout()
         .execute(EnterAlternateScreen)
@@ -54,16 +77,16 @@ fn init_terminal() -> Result<Atom, Error> {
     let backend = CrosstermBackend::new(std::io::stdout());
     let terminal = Terminal::new(backend).map_err(|e| Error::Term(Box::new(format!("{e}"))))?;
 
-    let mut guard = TERMINAL
-        .lock()
-        .map_err(|_| Error::Term(Box::new("terminal lock poisoned")))?;
-    *guard = Some(AnyTerminal::Crossterm(terminal));
-    Ok(atoms::ok())
+    Ok(ResourceArc::new(TerminalResource {
+        terminal: Mutex::new(Some(AnyTerminal::Crossterm(terminal))),
+        is_crossterm: true,
+    }))
 }
 
 #[rustler::nif]
-fn restore_terminal() -> Result<Atom, Error> {
-    let mut guard = TERMINAL
+fn restore_terminal(resource: ResourceArc<TerminalResource>) -> Result<Atom, Error> {
+    let mut guard = resource
+        .terminal
         .lock()
         .map_err(|_| Error::Term(Box::new("terminal lock poisoned")))?;
 
@@ -91,27 +114,20 @@ fn terminal_size() -> Result<(u16, u16), Error> {
 }
 
 #[rustler::nif]
-fn init_test_terminal(width: u16, height: u16) -> Result<Atom, Error> {
+fn init_test_terminal(width: u16, height: u16) -> Result<ResourceArc<TerminalResource>, Error> {
     let backend = TestBackend::new(width, height);
     let terminal = Terminal::new(backend).map_err(|e| Error::Term(Box::new(format!("{e}"))))?;
 
-    let mut guard = TERMINAL
-        .lock()
-        .map_err(|_| Error::Term(Box::new("terminal lock poisoned")))?;
-
-    // Clean up any existing real terminal
-    if let Some(AnyTerminal::Crossterm(_)) = guard.as_ref() {
-        let _ = terminal::disable_raw_mode();
-        let _ = std::io::stdout().execute(LeaveAlternateScreen);
-    }
-
-    *guard = Some(AnyTerminal::Test(terminal));
-    Ok(atoms::ok())
+    Ok(ResourceArc::new(TerminalResource {
+        terminal: Mutex::new(Some(AnyTerminal::Test(terminal))),
+        is_crossterm: false,
+    }))
 }
 
 #[rustler::nif]
-fn get_buffer_content() -> Result<String, Error> {
-    let guard = TERMINAL
+fn get_buffer_content(resource: ResourceArc<TerminalResource>) -> Result<String, Error> {
+    let guard = resource
+        .terminal
         .lock()
         .map_err(|_| Error::Term(Box::new("terminal lock poisoned")))?;
 

--- a/test/ex_ratatui/app_test.exs
+++ b/test/ex_ratatui/app_test.exs
@@ -1,5 +1,5 @@
 defmodule ExRatatui.AppTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   defmodule SampleApp do
     use ExRatatui.App
@@ -56,12 +56,6 @@ defmodule ExRatatui.AppTest do
 
     @impl true
     def handle_event(_event, state), do: {:noreply, state}
-  end
-
-  setup do
-    ExRatatui.Native.restore_terminal()
-    on_exit(fn -> ExRatatui.Native.restore_terminal() end)
-    :ok
   end
 
   test "start_link starts the server via App module" do

--- a/test/ex_ratatui/rendering_test.exs
+++ b/test/ex_ratatui/rendering_test.exs
@@ -1,5 +1,5 @@
 defmodule ExRatatui.RenderingTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias ExRatatui.Native
   alias ExRatatui.Layout.Rect
@@ -7,32 +7,32 @@ defmodule ExRatatui.RenderingTest do
   alias ExRatatui.Widgets.Paragraph
 
   setup do
-    Native.restore_terminal()
-    :ok = ExRatatui.init_test_terminal(40, 10)
-    on_exit(fn -> Native.restore_terminal() end)
-    :ok
+    terminal = ExRatatui.init_test_terminal(40, 10)
+    on_exit(fn -> Native.restore_terminal(terminal) end)
+    %{terminal: terminal}
   end
 
-  describe "draw/1" do
+  describe "draw/2" do
     test "returns error when terminal not initialized" do
-      Native.restore_terminal()
+      terminal = ExRatatui.init_test_terminal(40, 10)
+      Native.restore_terminal(terminal)
 
       paragraph = %Paragraph{text: "Hello"}
       rect = %Rect{x: 0, y: 0, width: 80, height: 24}
 
-      result = ExRatatui.draw([{paragraph, rect}])
+      result = ExRatatui.draw(terminal, [{paragraph, rect}])
       assert {:error, "terminal not initialized"} = result
     end
 
-    test "accepts paragraph with default style" do
+    test "accepts paragraph with default style", %{terminal: terminal} do
       paragraph = %Paragraph{text: "Hello, world!"}
       rect = %Rect{x: 0, y: 0, width: 40, height: 5}
 
-      assert :ok = ExRatatui.draw([{paragraph, rect}])
-      assert ExRatatui.get_buffer_content() =~ "Hello, world!"
+      assert :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      assert ExRatatui.get_buffer_content(terminal) =~ "Hello, world!"
     end
 
-    test "accepts paragraph with styled text" do
+    test "accepts paragraph with styled text", %{terminal: terminal} do
       paragraph = %Paragraph{
         text: "Styled text",
         style: %Style{fg: :green, bg: :black, modifiers: [:bold]},
@@ -42,11 +42,11 @@ defmodule ExRatatui.RenderingTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 5}
 
-      assert :ok = ExRatatui.draw([{paragraph, rect}])
-      assert ExRatatui.get_buffer_content() =~ "Styled text"
+      assert :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      assert ExRatatui.get_buffer_content(terminal) =~ "Styled text"
     end
 
-    test "accepts paragraph with RGB color" do
+    test "accepts paragraph with RGB color", %{terminal: terminal} do
       paragraph = %Paragraph{
         text: "RGB colored",
         style: %Style{fg: {:rgb, 255, 100, 0}}
@@ -54,24 +54,24 @@ defmodule ExRatatui.RenderingTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 5}
 
-      assert :ok = ExRatatui.draw([{paragraph, rect}])
-      assert ExRatatui.get_buffer_content() =~ "RGB colored"
+      assert :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      assert ExRatatui.get_buffer_content(terminal) =~ "RGB colored"
     end
 
-    test "accepts multiple widgets in one frame" do
+    test "accepts multiple widgets in one frame", %{terminal: terminal} do
       widgets = [
         {%Paragraph{text: "Top"}, %Rect{x: 0, y: 0, width: 40, height: 3}},
         {%Paragraph{text: "Bottom"}, %Rect{x: 0, y: 3, width: 40, height: 3}}
       ]
 
-      assert :ok = ExRatatui.draw(widgets)
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, widgets)
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Top"
       assert content =~ "Bottom"
     end
 
-    test "accepts empty widget list" do
-      assert :ok = ExRatatui.draw([])
+    test "accepts empty widget list", %{terminal: terminal} do
+      assert :ok = ExRatatui.draw(terminal, [])
     end
   end
 end

--- a/test/ex_ratatui/server_test.exs
+++ b/test/ex_ratatui/server_test.exs
@@ -1,7 +1,6 @@
 defmodule ExRatatui.ServerTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
-  alias ExRatatui.Native
   alias ExRatatui.Frame
 
   defmodule TestApp do
@@ -31,12 +30,6 @@ defmodule ExRatatui.ServerTest do
       send(state.test_pid, {:info, msg})
       {:noreply, state}
     end
-  end
-
-  setup do
-    Native.restore_terminal()
-    on_exit(fn -> Native.restore_terminal() end)
-    :ok
   end
 
   describe "start_link/1" do

--- a/test/ex_ratatui/terminal_test.exs
+++ b/test/ex_ratatui/terminal_test.exs
@@ -1,18 +1,14 @@
 defmodule ExRatatui.TerminalTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias ExRatatui.Native
 
   describe "NIF loading" do
     test "init_terminal NIF is loaded and callable" do
       result = Native.init_terminal()
-      assert result == :ok or match?({:error, _}, result)
+      assert is_reference(result) or match?({:error, _}, result)
 
-      if result == :ok, do: Native.restore_terminal()
-    end
-
-    test "restore_terminal NIF is loaded and callable" do
-      assert :ok = Native.restore_terminal()
+      if is_reference(result), do: Native.restore_terminal(result)
     end
 
     test "terminal_size NIF is loaded and callable" do
@@ -21,20 +17,9 @@ defmodule ExRatatui.TerminalTest do
     end
   end
 
-  describe "restore_terminal safety" do
-    test "restore without init is a safe no-op" do
-      assert :ok = Native.restore_terminal()
-    end
-
-    test "double restore is a safe no-op" do
-      assert :ok = Native.restore_terminal()
-      assert :ok = Native.restore_terminal()
-    end
-  end
-
   describe "run/1" do
     test "either executes the function (TTY) or returns error (no TTY)" do
-      result = ExRatatui.run(fn -> :ran end)
+      result = ExRatatui.run(fn _terminal -> :ran end)
 
       case result do
         :ran -> :ok
@@ -43,9 +28,10 @@ defmodule ExRatatui.TerminalTest do
     end
 
     test "ensures terminal is restored after function executes" do
-      ExRatatui.run(fn -> :ok end)
-      # restore is a safe no-op if already restored (or never initialized)
-      assert :ok = Native.restore_terminal()
+      ExRatatui.run(fn _terminal -> :ok end)
+      # If run succeeded, terminal was restored in the after block.
+      # If it failed (no TTY), nothing to restore.
+      assert true
     end
   end
 
@@ -60,7 +46,6 @@ defmodule ExRatatui.TerminalTest do
         end
 
       ExRatatui.terminal_size()
-      Native.restore_terminal()
 
       results = Task.await_many(tasks, 5000)
       assert Enum.all?(results, &(&1 == :alive))
@@ -70,45 +55,32 @@ defmodule ExRatatui.TerminalTest do
   describe "terminal lifecycle" do
     test "init and restore complete successfully" do
       case Native.init_terminal() do
-        :ok -> assert :ok = Native.restore_terminal()
         {:error, _} -> :ok
+        ref -> assert :ok = Native.restore_terminal(ref)
       end
     end
 
     test "terminal_size returns integers after init" do
       case Native.init_terminal() do
-        :ok ->
+        {:error, _} ->
+          :ok
+
+        ref ->
           assert {w, h} = ExRatatui.terminal_size()
           assert is_integer(w) and is_integer(h)
-          assert :ok = Native.restore_terminal()
-
-        {:error, _} ->
-          :ok
-      end
-    end
-
-    test "double init replaces terminal cleanly" do
-      case Native.init_terminal() do
-        :ok ->
-          :ok = Native.init_terminal()
-          assert :ok = Native.restore_terminal()
-
-        {:error, _} ->
-          :ok
+          assert :ok = Native.restore_terminal(ref)
       end
     end
 
     test "full ExRatatui.run/1 lifecycle" do
       ran? =
-        case ExRatatui.run(fn -> :ran end) do
+        case ExRatatui.run(fn _terminal -> :ran end) do
           :ran -> true
           {:error, _} -> false
         end
 
-      if ran? do
-        # Terminal should have been restored by run/1
-        assert :ok = Native.restore_terminal()
-      end
+      # If it ran, terminal was already restored by run/1
+      assert is_boolean(ran?)
     end
   end
 end

--- a/test/ex_ratatui/test_backend_test.exs
+++ b/test/ex_ratatui/test_backend_test.exs
@@ -1,79 +1,82 @@
 defmodule ExRatatui.TestBackendTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias ExRatatui.Native
   alias ExRatatui.Layout.Rect
   alias ExRatatui.Widgets.{Block, Gauge, List, Paragraph, Table}
 
   setup do
-    Native.restore_terminal()
-    :ok = ExRatatui.init_test_terminal(40, 10)
-    on_exit(fn -> Native.restore_terminal() end)
-    :ok
+    terminal = ExRatatui.init_test_terminal(40, 10)
+    on_exit(fn -> Native.restore_terminal(terminal) end)
+    %{terminal: terminal}
   end
 
   describe "test terminal lifecycle" do
     test "init_test_terminal and restore" do
-      assert :ok = ExRatatui.init_test_terminal(20, 5)
-      assert :ok = Native.restore_terminal()
+      terminal = ExRatatui.init_test_terminal(20, 5)
+      assert :ok = Native.restore_terminal(terminal)
     end
 
     test "get_buffer_content returns empty buffer initially" do
-      :ok = ExRatatui.init_test_terminal(10, 3)
-      content = ExRatatui.get_buffer_content()
+      terminal = ExRatatui.init_test_terminal(10, 3)
+      content = ExRatatui.get_buffer_content(terminal)
       assert is_binary(content)
+      Native.restore_terminal(terminal)
     end
 
-    test "get_buffer_content errors without test terminal" do
-      Native.restore_terminal()
-      assert {:error, _} = ExRatatui.get_buffer_content()
+    test "get_buffer_content errors after terminal restored" do
+      terminal = ExRatatui.init_test_terminal(10, 3)
+      Native.restore_terminal(terminal)
+      assert {:error, _} = ExRatatui.get_buffer_content(terminal)
     end
   end
 
   describe "rendering verification with TestBackend" do
-    test "paragraph text appears in buffer" do
+    test "paragraph text appears in buffer", %{terminal: terminal} do
       paragraph = %Paragraph{text: "Hello, ExRatatui!"}
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      :ok = ExRatatui.draw([{paragraph, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Hello, ExRatatui!"
     end
 
     test "paragraph with centered alignment" do
-      :ok = ExRatatui.init_test_terminal(20, 3)
+      terminal = ExRatatui.init_test_terminal(20, 3)
 
       paragraph = %Paragraph{text: "Hi", alignment: :center}
       rect = %Rect{x: 0, y: 0, width: 20, height: 3}
 
-      :ok = ExRatatui.draw([{paragraph, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       # "Hi" should be centered — not starting at column 0
       [first_line | _] = String.split(content, "\n")
       assert String.starts_with?(first_line, " ")
       assert first_line =~ "Hi"
+
+      Native.restore_terminal(terminal)
     end
 
-    test "multiline paragraph" do
+    test "multiline paragraph", %{terminal: terminal} do
       paragraph = %Paragraph{text: "Line 1\nLine 2\nLine 3"}
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      :ok = ExRatatui.draw([{paragraph, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Line 1"
       assert content =~ "Line 2"
       assert content =~ "Line 3"
     end
 
-    test "block with borders renders box characters" do
+    test "block with borders renders box characters", %{terminal: terminal} do
       block = %Block{borders: [:all], border_type: :plain}
       rect = %Rect{x: 0, y: 0, width: 20, height: 5}
 
-      :ok = ExRatatui.draw([{block, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{block, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       # Should contain box-drawing characters
       assert content =~ "┌"
@@ -82,28 +85,28 @@ defmodule ExRatatui.TestBackendTest do
       assert content =~ "┘"
     end
 
-    test "block with title" do
+    test "block with title", %{terminal: terminal} do
       block = %Block{title: "My Title", borders: [:all]}
       rect = %Rect{x: 0, y: 0, width: 20, height: 5}
 
-      :ok = ExRatatui.draw([{block, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{block, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "My Title"
     end
 
-    test "block with rounded borders" do
+    test "block with rounded borders", %{terminal: terminal} do
       block = %Block{borders: [:all], border_type: :rounded}
       rect = %Rect{x: 0, y: 0, width: 20, height: 3}
 
-      :ok = ExRatatui.draw([{block, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{block, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "╭"
       assert content =~ "╯"
     end
 
-    test "paragraph inside a block" do
+    test "paragraph inside a block", %{terminal: terminal} do
       paragraph = %Paragraph{
         text: "Boxed text",
         block: %Block{title: "Box", borders: [:all]}
@@ -111,27 +114,27 @@ defmodule ExRatatui.TestBackendTest do
 
       rect = %Rect{x: 0, y: 0, width: 30, height: 5}
 
-      :ok = ExRatatui.draw([{paragraph, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Box"
       assert content =~ "Boxed text"
       assert content =~ "┌"
     end
 
-    test "list renders items" do
+    test "list renders items", %{terminal: terminal} do
       list = %List{items: ["Alpha", "Beta", "Gamma"]}
       rect = %Rect{x: 0, y: 0, width: 20, height: 5}
 
-      :ok = ExRatatui.draw([{list, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{list, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Alpha"
       assert content =~ "Beta"
       assert content =~ "Gamma"
     end
 
-    test "list with selection shows highlight symbol" do
+    test "list with selection shows highlight symbol", %{terminal: terminal} do
       list = %List{
         items: ["One", "Two", "Three"],
         highlight_symbol: ">> ",
@@ -140,14 +143,14 @@ defmodule ExRatatui.TestBackendTest do
 
       rect = %Rect{x: 0, y: 0, width: 20, height: 5}
 
-      :ok = ExRatatui.draw([{list, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{list, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ ">>"
       assert content =~ "Two"
     end
 
-    test "table renders rows" do
+    test "table renders rows", %{terminal: terminal} do
       table = %Table{
         rows: [["Alice", "30"], ["Bob", "25"]],
         widths: [{:length, 10}, {:length, 10}]
@@ -155,8 +158,8 @@ defmodule ExRatatui.TestBackendTest do
 
       rect = %Rect{x: 0, y: 0, width: 30, height: 5}
 
-      :ok = ExRatatui.draw([{table, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{table, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Alice"
       assert content =~ "Bob"
@@ -164,7 +167,7 @@ defmodule ExRatatui.TestBackendTest do
       assert content =~ "25"
     end
 
-    test "table with header" do
+    test "table with header", %{terminal: terminal} do
       table = %Table{
         rows: [["Alice", "30"]],
         header: ["Name", "Age"],
@@ -173,33 +176,33 @@ defmodule ExRatatui.TestBackendTest do
 
       rect = %Rect{x: 0, y: 0, width: 30, height: 5}
 
-      :ok = ExRatatui.draw([{table, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{table, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Name"
       assert content =~ "Age"
       assert content =~ "Alice"
     end
 
-    test "gauge with label" do
+    test "gauge with label", %{terminal: terminal} do
       gauge = %Gauge{ratio: 0.5, label: "50%"}
       rect = %Rect{x: 0, y: 0, width: 20, height: 1}
 
-      :ok = ExRatatui.draw([{gauge, rect}])
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, [{gauge, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "50%"
     end
 
-    test "multiple widgets in one frame" do
+    test "multiple widgets in one frame", %{terminal: terminal} do
       widgets = [
         {%Paragraph{text: "Header"}, %Rect{x: 0, y: 0, width: 40, height: 1}},
         {%List{items: ["a", "b"]}, %Rect{x: 0, y: 1, width: 40, height: 3}},
         {%Gauge{ratio: 0.75, label: "75%"}, %Rect{x: 0, y: 4, width: 40, height: 1}}
       ]
 
-      :ok = ExRatatui.draw(widgets)
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, widgets)
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Header"
       assert content =~ "a"
@@ -207,10 +210,8 @@ defmodule ExRatatui.TestBackendTest do
       assert content =~ "75%"
     end
 
-    test "layout split + rendering" do
+    test "layout split + rendering", %{terminal: terminal} do
       alias ExRatatui.Layout
-
-      :ok = ExRatatui.init_test_terminal(40, 10)
 
       area = %Rect{x: 0, y: 0, width: 40, height: 10}
       [top, bottom] = Layout.split(area, :vertical, [{:length, 1}, {:min, 0}])
@@ -220,8 +221,8 @@ defmodule ExRatatui.TestBackendTest do
         {%Paragraph{text: "Bottom section"}, bottom}
       ]
 
-      :ok = ExRatatui.draw(widgets)
-      content = ExRatatui.get_buffer_content()
+      :ok = ExRatatui.draw(terminal, widgets)
+      content = ExRatatui.get_buffer_content(terminal)
 
       assert content =~ "Top section"
       assert content =~ "Bottom section"

--- a/test/ex_ratatui/widgets_test.exs
+++ b/test/ex_ratatui/widgets_test.exs
@@ -1,5 +1,5 @@
 defmodule ExRatatui.WidgetsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias ExRatatui.Native
   alias ExRatatui.Layout.Rect
@@ -7,14 +7,13 @@ defmodule ExRatatui.WidgetsTest do
   alias ExRatatui.Widgets.{Block, Gauge, List, Paragraph, Table}
 
   setup do
-    Native.restore_terminal()
-    :ok = ExRatatui.init_test_terminal(60, 15)
-    on_exit(fn -> Native.restore_terminal() end)
-    :ok
+    terminal = ExRatatui.init_test_terminal(60, 15)
+    on_exit(fn -> Native.restore_terminal(terminal) end)
+    %{terminal: terminal}
   end
 
   describe "Block widget" do
-    test "encoding a standalone block does not raise" do
+    test "encoding a standalone block does not raise", %{terminal: terminal} do
       block = %Block{
         title: "My Block",
         borders: [:all],
@@ -24,19 +23,19 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      assert :ok = ExRatatui.draw([{block, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{block, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "My Block"
     end
 
-    test "block with individual borders" do
+    test "block with individual borders", %{terminal: terminal} do
       block = %Block{borders: [:top, :bottom], border_type: :plain}
       rect = %Rect{x: 0, y: 0, width: 20, height: 5}
 
-      assert :ok = ExRatatui.draw([{block, rect}])
+      assert :ok = ExRatatui.draw(terminal, [{block, rect}])
     end
 
-    test "block with padding" do
+    test "block with padding", %{terminal: terminal} do
       block = %Block{
         borders: [:all],
         padding: {1, 1, 1, 1}
@@ -44,12 +43,12 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 20, height: 5}
 
-      assert :ok = ExRatatui.draw([{block, rect}])
+      assert :ok = ExRatatui.draw(terminal, [{block, rect}])
     end
   end
 
   describe "Paragraph with block" do
-    test "paragraph inside a block" do
+    test "paragraph inside a block", %{terminal: terminal} do
       paragraph = %Paragraph{
         text: "Inside a box",
         style: %Style{fg: :cyan},
@@ -63,15 +62,15 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      assert :ok = ExRatatui.draw([{paragraph, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{paragraph, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Inside a box"
       assert content =~ "Title"
     end
   end
 
   describe "List widget" do
-    test "simple list" do
+    test "simple list", %{terminal: terminal} do
       list = %List{
         items: ["Alpha", "Beta", "Gamma"],
         style: %Style{fg: :white}
@@ -79,14 +78,14 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 30, height: 10}
 
-      assert :ok = ExRatatui.draw([{list, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{list, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Alpha"
       assert content =~ "Beta"
       assert content =~ "Gamma"
     end
 
-    test "list with selection" do
+    test "list with selection", %{terminal: terminal} do
       list = %List{
         items: ["One", "Two", "Three"],
         highlight_style: %Style{fg: :yellow, modifiers: [:bold]},
@@ -96,13 +95,13 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 30, height: 10}
 
-      assert :ok = ExRatatui.draw([{list, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{list, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ ">>"
       assert content =~ "Two"
     end
 
-    test "list with block" do
+    test "list with block", %{terminal: terminal} do
       list = %List{
         items: ["Item A", "Item B"],
         block: %Block{title: "My List", borders: [:all]}
@@ -110,15 +109,15 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 30, height: 10}
 
-      assert :ok = ExRatatui.draw([{list, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{list, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "My List"
       assert content =~ "Item A"
     end
   end
 
   describe "Table widget" do
-    test "simple table" do
+    test "simple table", %{terminal: terminal} do
       table = %Table{
         rows: [["Alice", "30"], ["Bob", "25"]],
         widths: [{:length, 15}, {:length, 10}]
@@ -126,13 +125,13 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      assert :ok = ExRatatui.draw([{table, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{table, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Alice"
       assert content =~ "Bob"
     end
 
-    test "table with header" do
+    test "table with header", %{terminal: terminal} do
       table = %Table{
         rows: [["Alice", "30"], ["Bob", "25"]],
         header: ["Name", "Age"],
@@ -141,14 +140,14 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      assert :ok = ExRatatui.draw([{table, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{table, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Name"
       assert content =~ "Age"
       assert content =~ "Alice"
     end
 
-    test "table with selection and block" do
+    test "table with selection and block", %{terminal: terminal} do
       table = %Table{
         rows: [["Row 1"], ["Row 2"], ["Row 3"]],
         widths: [{:percentage, 100}],
@@ -160,13 +159,13 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 10}
 
-      assert :ok = ExRatatui.draw([{table, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{table, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Data"
       assert content =~ "Row 1"
     end
 
-    test "table with percentage widths" do
+    test "table with percentage widths", %{terminal: terminal} do
       table = %Table{
         rows: [["A", "B", "C"]],
         widths: [{:percentage, 33}, {:percentage, 33}, {:percentage, 34}]
@@ -174,8 +173,8 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 60, height: 5}
 
-      assert :ok = ExRatatui.draw([{table, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{table, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "A"
       assert content =~ "B"
       assert content =~ "C"
@@ -183,7 +182,7 @@ defmodule ExRatatui.WidgetsTest do
   end
 
   describe "Gauge widget" do
-    test "basic gauge" do
+    test "basic gauge", %{terminal: terminal} do
       gauge = %Gauge{
         ratio: 0.5,
         gauge_style: %Style{fg: :green}
@@ -191,10 +190,10 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 1}
 
-      assert :ok = ExRatatui.draw([{gauge, rect}])
+      assert :ok = ExRatatui.draw(terminal, [{gauge, rect}])
     end
 
-    test "gauge with label and block" do
+    test "gauge with label and block", %{terminal: terminal} do
       gauge = %Gauge{
         ratio: 0.75,
         label: "75%",
@@ -204,37 +203,37 @@ defmodule ExRatatui.WidgetsTest do
 
       rect = %Rect{x: 0, y: 0, width: 40, height: 3}
 
-      assert :ok = ExRatatui.draw([{gauge, rect}])
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, [{gauge, rect}])
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "75%"
       assert content =~ "Progress"
     end
 
-    test "gauge with zero ratio" do
+    test "gauge with zero ratio", %{terminal: terminal} do
       gauge = %Gauge{ratio: 0.0}
       rect = %Rect{x: 0, y: 0, width: 20, height: 1}
 
-      assert :ok = ExRatatui.draw([{gauge, rect}])
+      assert :ok = ExRatatui.draw(terminal, [{gauge, rect}])
     end
 
-    test "gauge with integer ratio coerced to float" do
+    test "gauge with integer ratio coerced to float", %{terminal: terminal} do
       gauge = %Gauge{ratio: 1}
       rect = %Rect{x: 0, y: 0, width: 20, height: 1}
 
-      assert :ok = ExRatatui.draw([{gauge, rect}])
+      assert :ok = ExRatatui.draw(terminal, [{gauge, rect}])
     end
   end
 
   describe "mixed widgets in one frame" do
-    test "multiple widget types in a single draw call" do
+    test "multiple widget types in a single draw call", %{terminal: terminal} do
       widgets = [
         {%Paragraph{text: "Header"}, %Rect{x: 0, y: 0, width: 40, height: 3}},
         {%List{items: ["a", "b"]}, %Rect{x: 0, y: 3, width: 40, height: 5}},
         {%Gauge{ratio: 0.5}, %Rect{x: 0, y: 8, width: 40, height: 1}}
       ]
 
-      assert :ok = ExRatatui.draw(widgets)
-      content = ExRatatui.get_buffer_content()
+      assert :ok = ExRatatui.draw(terminal, widgets)
+      content = ExRatatui.get_buffer_content(terminal)
       assert content =~ "Header"
       assert content =~ "a"
       assert content =~ "b"


### PR DESCRIPTION
## Summary

- Replace global `static TERMINAL: Mutex<Option<AnyTerminal>>` with per-process `ResourceArc<TerminalResource>`
- Each caller gets its own terminal reference, garbage-collected by the BEAM
- Rust `Drop` impl auto-restores the terminal on process crash (no more stuck raw mode)
- Rendering/widget/backend tests now run `async: true` (independent terminal instances)

