### PR TITLE
fix: honour `config :rustler_precompiled, :force_build, ex_ratatui: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **`config :rustler_precompiled, :force_build, ex_ratatui: true` now actually forces a build from source.** `ExRatatui.Native` always put a `:force_build` key into the option list (derived from `EX_RATATUI_BUILD`) and then tried to apply the per-application config with `Keyword.put_new/3`, which never overwrites an existing key — so the documented `rustler_precompiled` escape hatch was silently ignored and the precompiled NIF was downloaded anyway. The three inputs are now resolved explicitly, highest precedence first: `:force_build_all` (or `RUSTLER_PRECOMPILED_FORCE_BUILD_ALL`), then `config :rustler_precompiled, :force_build, ex_ratatui: true/false`, then `EX_RATATUI_BUILD`. Behaviour is unchanged when the per-application config is absent.
+
 - **Corrected the OTP 29 note in the README.** It claimed OTP 29 had no precompiled binary and required the Rust toolchain plus `EX_RATATUI_BUILD=true`. Not so: the NIF ABI is backward compatible and `rustler_precompiled` selects the highest available version at or below the current one, so OTP 29 (NIF 2.18) loads the published 2.17 binary with no Rust toolchain. Only publishing a *native* 2.18 artifact is still pending upstream support. The 0.11.2 entry below carried the same error and has been corrected in place — no behaviour changed, only its description.
 
 ## [0.11.2] - 2026-07-31

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ To compile from source instead, install the [Rust toolchain](https://rustup.rs/)
 export EX_RATATUI_BUILD=true
 ```
 
+Or, without an env var, in your `config/config.exs`:
+
+```elixir
+config :rustler_precompiled, :force_build, ex_ratatui: true
+```
+
+The application config takes precedence over `EX_RATATUI_BUILD`, and `config :rustler_precompiled, force_build_all: true` takes precedence over both.
+
 ## Quick Start
 
 ```elixir

--- a/lib/ex_ratatui/native.ex
+++ b/lib/ex_ratatui/native.ex
@@ -1,6 +1,8 @@
 defmodule ExRatatui.Native do
   @moduledoc false
 
+  alias ExRatatui.Native.BuildConfig
+
   @otp_app :ex_ratatui
   @load_lock {__MODULE__, :nif_load_lock}
   @loaded_key {__MODULE__, :nif_loaded}
@@ -59,11 +61,33 @@ defmodule ExRatatui.Native do
 
   version = Mix.Project.config()[:version]
 
+  # Precedence, highest first:
+  #
+  #   1. config :rustler_precompiled, force_build_all: true
+  #      (or RUSTLER_PRECOMPILED_FORCE_BUILD_ALL=1)
+  #   2. config :rustler_precompiled, :force_build, ex_ratatui: true
+  #   3. EX_RATATUI_BUILD=1
+  #
+  # Resolved eagerly here, before the option list is handed to
+  # RustlerPrecompiled: the `:force_build` key must carry the final answer,
+  # because anything that tries to fill it in later can only use
+  # `Keyword.put_new/3` and would find the key already set.
+  force_build? =
+    BuildConfig.force_build?(
+      Application.compile_env(
+        :rustler_precompiled,
+        :force_build_all,
+        BuildConfig.truthy?(System.get_env("RUSTLER_PRECOMPILED_FORCE_BUILD_ALL"))
+      ),
+      Application.compile_env(:rustler_precompiled, [:force_build, @otp_app]),
+      System.get_env("EX_RATATUI_BUILD")
+    )
+
   precompiled_opts = [
     otp_app: @otp_app,
     crate: "ex_ratatui",
     base_url: "https://github.com/mcass19/ex_ratatui/releases/download/v#{version}",
-    force_build: System.get_env("EX_RATATUI_BUILD") in ["1", "true"],
+    force_build: force_build?,
     version: version,
     targets: ~w(
       aarch64-apple-darwin
@@ -79,21 +103,6 @@ defmodule ExRatatui.Native do
     ),
     nif_versions: ["2.16", "2.17"]
   ]
-
-  precompiled_opts =
-    if Application.compile_env(
-         :rustler_precompiled,
-         :force_build_all,
-         System.get_env("RUSTLER_PRECOMPILED_FORCE_BUILD_ALL") in ["1", "true"]
-       ) do
-      Keyword.put(precompiled_opts, :force_build, true)
-    else
-      Keyword.put_new(
-        precompiled_opts,
-        :force_build,
-        Application.compile_env(:rustler_precompiled, [:force_build, @otp_app])
-      )
-    end
 
   case RustlerPrecompiled.__using__(__MODULE__, precompiled_opts) do
     {:force_build, rustler_opts} ->

--- a/lib/ex_ratatui/native/build_config.ex
+++ b/lib/ex_ratatui/native/build_config.ex
@@ -1,0 +1,37 @@
+defmodule ExRatatui.Native.BuildConfig do
+  @moduledoc false
+
+  # Resolves whether the Rust NIF should be built from source instead of
+  # downloading a precompiled artifact.
+  #
+  # Kept in its own module so the precedence rules are plain functions that can
+  # be unit tested — the call site in `ExRatatui.Native` runs at compile time,
+  # where the inputs come from `Application.compile_env/3` and `System.get_env/1`
+  # and cannot be varied from a test.
+
+  @truthy ["1", "true"]
+
+  @doc false
+  @spec truthy?(String.t() | nil) :: boolean()
+  def truthy?(value), do: value in @truthy
+
+  @doc false
+  @spec force_build?(term(), term(), String.t() | nil) :: boolean()
+  def force_build?(force_build_all?, per_app_config, env_value) do
+    cond do
+      # `:force_build_all` (or RUSTLER_PRECOMPILED_FORCE_BUILD_ALL) wins over
+      # everything, per the rustler_precompiled contract.
+      force_build_all? ->
+        true
+
+      # `config :rustler_precompiled, :force_build, ex_ratatui: true` — the
+      # per-application override documented by rustler_precompiled.
+      is_boolean(per_app_config) ->
+        per_app_config
+
+      # Project-specific fallback for people who prefer an env var.
+      true ->
+        truthy?(env_value)
+    end
+  end
+end

--- a/test/ex_ratatui/native/build_config_test.exs
+++ b/test/ex_ratatui/native/build_config_test.exs
@@ -1,0 +1,46 @@
+defmodule ExRatatui.Native.BuildConfigTest do
+  use ExUnit.Case, async: true
+
+  alias ExRatatui.Native.BuildConfig
+
+  describe "truthy?/1" do
+    test "accepts the documented truthy env var values" do
+      assert BuildConfig.truthy?("1")
+      assert BuildConfig.truthy?("true")
+    end
+
+    test "rejects everything else, including an unset variable" do
+      refute BuildConfig.truthy?("0")
+      refute BuildConfig.truthy?("false")
+      refute BuildConfig.truthy?("yes")
+      refute BuildConfig.truthy?(nil)
+    end
+  end
+
+  describe "force_build?/3" do
+    test "force_build_all wins over the per-app config and the env var" do
+      assert BuildConfig.force_build?(true, false, nil)
+      assert BuildConfig.force_build?(true, nil, "0")
+    end
+
+    test "per-app config takes effect when force_build_all is off" do
+      assert BuildConfig.force_build?(false, true, nil)
+    end
+
+    test "per-app config of false wins over a truthy env var" do
+      refute BuildConfig.force_build?(false, false, "true")
+    end
+
+    test "falls back to the env var when the per-app config is absent" do
+      assert BuildConfig.force_build?(false, nil, "1")
+      assert BuildConfig.force_build?(false, nil, "true")
+      refute BuildConfig.force_build?(false, nil, nil)
+      refute BuildConfig.force_build?(false, nil, "false")
+    end
+
+    test "ignores a non-boolean per-app config and falls back to the env var" do
+      assert BuildConfig.force_build?(false, "true", "1")
+      refute BuildConfig.force_build?(false, "true", nil)
+    end
+  end
+end


### PR DESCRIPTION
## What's broken

`config :rustler_precompiled, :force_build, ex_ratatui: true` — the per-application escape hatch that `rustler_precompiled` documents (and that it prints in its own error message when a NIF download fails) — does nothing. The precompiled NIF is downloaded anyway.

## Why

In `lib/ex_ratatui/native.ex`, the option list is built with `:force_build` **always present**:

```elixir
precompiled_opts = [
  ...
  force_build: System.get_env("EX_RATATUI_BUILD") in ["1", "true"],   # key is always set
  ...
]
```

and the per-app config is then applied with `Keyword.put_new/3`:

```elixir
Keyword.put_new(
  precompiled_opts,
  :force_build,
  Application.compile_env(:rustler_precompiled, [:force_build, @otp_app])
)
```

`Keyword.put_new/3` is a no-op when the key already exists, and it always exists — so the config value is computed and thrown away. `EX_RATATUI_BUILD` being unset resolves to `false`, not "absent", which is exactly the case the `put_new` was meant to fill in.

(For what it's worth, this shape is inherited from the `RustlerPrecompiled` `__using__` macro, which `ExRatatui.Native` inlines in order to make NIF loading lazy. The same interaction is latent there for any library that passes an env-var-derived `:force_build`.)

## The fix

Resolve the three inputs explicitly, highest precedence first:

1. `config :rustler_precompiled, force_build_all: true` (or `RUSTLER_PRECOMPILED_FORCE_BUILD_ALL=1`)
2. `config :rustler_precompiled, :force_build, ex_ratatui: true | false`
3. `EX_RATATUI_BUILD=1|true`

which matches the precedence `rustler_precompiled` documents. Behaviour is unchanged when the per-application config is absent — a non-boolean or missing value falls through to the env var, so no existing setup changes.

The precedence rules moved into `ExRatatui.Native.BuildConfig` as plain functions. That is the only testable seam here: the call site in `ExRatatui.Native` runs at compile time, so a test cannot vary `Application.compile_env/3` or `System.get_env/1` for it. The `compile_env/3` calls stay at the call site so a config change still invalidates the compiled module.

## How it was verified

End-to-end, on macOS/aarch64, with `EX_RATATUI_BUILD` and `RUSTLER_PRECOMPILED_FORCE_BUILD_ALL` unset and a `config/config.exs` containing only:

```elixir
config :rustler_precompiled, :force_build, ex_ratatui: true
```

**Before (`main`, `mix compile`)** — config ignored, precompiled artifact used:

```
Compiling 92 files (.ex)
[debug] Copying NIF from cache and extracting to .../priv/native/libex_ratatui-v0.11.2-nif-2.17-aarch64-apple-darwin.so.tar.gz
Generated ex_ratatui app
```

**After (this branch, `mix compile`)** — config honoured, crate built from source:

```
Compiling 2 files (.ex)
Compiling crate ex_ratatui in release mode (native/ex_ratatui)
Copying .../native/ex_ratatui/target/release/libex_ratatui.dylib to priv/native/ex_ratatui.so
Generated ex_ratatui app
```

No-regression checks on this branch, `mix compile --force`:

| config | env | result |
| --- | --- | --- |
| none | none | `Copying NIF from cache …` (precompiled, unchanged) |
| none | `EX_RATATUI_BUILD=true` | `Compiling crate ex_ratatui in release mode` (unchanged) |
| `force_build: [ex_ratatui: true]` | none | `Compiling crate ex_ratatui in release mode` (**fixed**) |

Plus the checks from CONTRIBUTING.md:

- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean
- `mix credo --strict` — `1433 mods/funs, found no issues`
- `mix dialyzer` — `Total errors: 0, Skipped: 0, Unnecessary Skips: 0` / `done (passed successfully)`
- `mix test --cover` — `1499 passed (168 doctests, 116 properties, 1215 tests), 27 excluded`, total coverage `100.00%`, `ExRatatui.Native.BuildConfig` at `100.00%`
- `mix deps.unlock --check-unused` and `mix xref graph --format cycles --fail-above 0` (from CI) — clean, `No cycles found`
- `mix rust.check` — unchanged by this PR (no Rust touched)

## Notes

- CHANGELOG entry added under `[Unreleased] / Fixed`.
- README now mentions the config option alongside `EX_RATATUI_BUILD`, and states the precedence.
- Unrelated, but found while building a musl release against this library: the published `*-unknown-linux-musl` NIFs cannot be loaded on a bare musl system. Filed separately as #83.
