### PR TITLE
build(nif): size-tuned release profile (strip, fat LTO, codegen-units=1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Smaller precompiled NIF.** The Rust crate now builds with a size-tuned release profile (`strip = "symbols"`, fat LTO, `codegen-units = 1`), shrinking the artifact by ~13% on disk (5.3 → 4.6 MB on x86_64-linux-gnu) and ~9% as a download (2.36 → 2.14 MB compressed) with no functional change. `opt-level` deliberately stays at the default 3 — `"s"`/`"z"` would shrink further but de-prioritize the hot paths (the 3D rasterizer, image decode, sixel quantization). Headless render benchmarks across core widgets, markdown/syntect highlighting, and both 3D pipelines show frame times flat to slightly improved (raytrace ~6% faster from LTO).
+
 ## [0.13.0] - 2026-08-13
 
 ### Added

--- a/native/ex_ratatui/Cargo.toml
+++ b/native/ex_ratatui/Cargo.toml
@@ -31,3 +31,11 @@ cc = "1"
 default = ["nif_version_2_16"]
 nif_version_2_16 = ["rustler/nif_version_2_16"]
 nif_version_2_17 = ["rustler/nif_version_2_17"]
+
+# Size-tuned release profile for the precompiled artifacts. `opt-level` stays
+# at the default 3: "s"/"z" shrink further but de-prioritize the hot paths
+# (3D rasterizer, image decode, sixel quantization).
+[profile.release]
+strip = "symbols"
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Adds a `[profile.release]` section to the NIF crate so every precompiled artifact ships smaller.

## Benchmark

It mounts a 120×40 test terminal via `ExRatatui.init_test_terminal/2` and times `ExRatatui.draw/2` (20-frame warmup, then n timed frames; avg/p50/p99).

Raw numbers:

```
before (main, 2edcfc1):
core widgets           avg     375  p50     370  p99     503  (n=500)
markdown+highlight     avg     210  p50     209  p99     255  (n=500)
code block (syntect)   avg     233  p50     232  p99     253  (n=500)
3d rasterize braille   avg     249  p50     248  p99     287  (n=200)
3d raytrace halfblock  avg   21178  p50   21103  p99   21867  (n=50)

after (profile change):
core widgets           avg     375  p50     374  p99     418  (n=500)
markdown+highlight     avg     207  p50     207  p99     222  (n=500)
code block (syntect)   avg     235  p50     234  p99     350  (n=500)
3d rasterize braille   avg     244  p50     243  p99     264  (n=200)
3d raytrace halfblock  avg   19860  p50   19781  p99   20749  (n=50)
```
