### PR TITLE
fix panic when resizing: clip each draw command to the frame area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Drawing no longer panics when a widget area exceeds the buffer.** The terminal autoresizes inside `draw`, so a frame planned before a window or pty shrink can carry areas past the new buffer; ratatui's widgets clip themselves, but `WidgetList` blits rows by raw buffer index and panicked inside the NIF (`index outside of buffer`). Every widget area is now intersected with the target buffer at the one rendering entry point, so `draw/2`, `Session`, `CellSession` and nested content (`Popup`, `WidgetList` items) are all covered.
+
 ### Changed
 
 - **Smaller precompiled NIF.** The Rust crate now builds with a size-tuned release profile (`strip = "symbols"`, fat LTO, `codegen-units = 1`), shrinking the artifact by ~13% on disk (5.3 → 4.6 MB on x86_64-linux-gnu) and ~9% as a download (2.36 → 2.14 MB compressed) with no functional change. `opt-level` deliberately stays at the default 3 — `"s"`/`"z"` would shrink further but de-prioritize the hot paths (the 3D rasterizer, image decode, sixel quantization). Headless render benchmarks across core widgets, markdown/syntect highlighting, and both 3D pipelines show frame times flat to slightly improved (raytrace ~6% faster from LTO).

--- a/native/ex_ratatui/src/rendering.rs
+++ b/native/ex_ratatui/src/rendering.rs
@@ -1493,6 +1493,10 @@ fn render_widget(frame: &mut ratatui::Frame, cmd: &RenderCommand, caps: Transpor
 }
 
 pub fn render_widget_data(buf: &mut Buffer, widget: &WidgetData, area: Rect, caps: TransportCaps) {
+    // Ratatui's widgets clip themselves, but WidgetList blits rows by raw
+    // index; clamp once here so draw, sessions, CellSession and nested
+    // widgets are all safe when a frame outlives a window shrink.
+    let area = area.intersection(*buf.area());
     match widget {
         WidgetData::Paragraph(data) => paragraph::render(buf, data, area),
         WidgetData::BigText(data) => big_text::render(buf, data, area),

--- a/test/ex_ratatui/cell_session_test.exs
+++ b/test/ex_ratatui/cell_session_test.exs
@@ -537,6 +537,32 @@ defmodule ExRatatui.CellSessionTest do
       :ok = CellSession.close(session)
     end
 
+    test "draw/2 clips a widget area to the session buffer instead of panicking" do
+      # A scrolled WidgetList blits rows by raw buffer index; an area past the
+      # buffer (a frame planned before a pty shrink) must clip, not panic.
+      alias ExRatatui.Widgets.WidgetList
+
+      session = CellSession.new(20, 5)
+      item = %Paragraph{text: "one\ntwo\nthree"}
+      list = %WidgetList{items: [{item, 3}, {item, 3}], scroll_offset: 1}
+      past_right = %Rect{x: 15, y: 0, width: 10, height: 3}
+      past_bottom = %Rect{x: 0, y: 4, width: 8, height: 4}
+      outside = %Rect{x: 25, y: 7, width: 4, height: 2}
+
+      assert :ok =
+               CellSession.draw(session, [
+                 {list, past_right},
+                 {list, past_bottom},
+                 {list, outside}
+               ])
+
+      %Snapshot{cells: cells} = CellSession.take_cells(session)
+      row0 = cells |> Enum.filter(&(&1.row == 0)) |> Enum.map_join(& &1.symbol)
+      assert row0 =~ "two"
+
+      :ok = CellSession.close(session)
+    end
+
     test "take_cells/1 returns a Snapshot of Cell structs" do
       session = CellSession.new(3, 1)
       :ok = CellSession.draw(session, [])

--- a/test/integration/rendering_test.exs
+++ b/test/integration/rendering_test.exs
@@ -24,6 +24,25 @@ defmodule ExRatatui.Integration.RenderingTest do
       assert {:error, "terminal not initialized"} = result
     end
 
+    test "clips a widget area to the frame instead of panicking", %{terminal: terminal} do
+      # A frame planned for a bigger terminal can reach `draw/2` after the
+      # terminal shrank (autoresize happens inside draw), so a command's area
+      # may lie past the buffer. Ratatui's own widgets clip themselves; a
+      # scrolled WidgetList blits rows by raw buffer index and panicked.
+      alias ExRatatui.Widgets.WidgetList
+
+      item = %Paragraph{text: "one\ntwo\nthree"}
+      list = %WidgetList{items: [{item, 3}, {item, 3}], scroll_offset: 1}
+      past_right = %Rect{x: 30, y: 0, width: 20, height: 4}
+      past_bottom = %Rect{x: 0, y: 8, width: 10, height: 5}
+      outside = %Rect{x: 45, y: 12, width: 5, height: 2}
+
+      assert :ok =
+               ExRatatui.draw(terminal, [{list, past_right}, {list, past_bottom}, {list, outside}])
+
+      assert ExRatatui.get_buffer_content(terminal) =~ "two"
+    end
+
     test "accepts paragraph with default style", %{terminal: terminal} do
       paragraph = %Paragraph{text: "Hello, world!"}
       rect = %Rect{x: 0, y: 0, width: 40, height: 5}


### PR DESCRIPTION
The terminal autoresizes inside draw, so a frame planned before a window shrink can carry areas past the new buffer. Ratatui's widgets clip themselves, but WidgetList blits rows by raw buffer index and panicked ("index outside of buffer"). Intersect every command's area with the frame once, in render_widget.